### PR TITLE
OID-based asset references filter by `ID` using full OID token

### DIFF
--- a/v1-slaug.js
+++ b/v1-slaug.js
@@ -168,7 +168,7 @@ function assetOidTrigger(match) {
 }
 
 function expandAssetOid(oid, assetType, assetID, channel) {
-	return _expand(oid, assetType, 'Key', assetID, channel)
+	return _expand(oid, assetType, 'ID', `${assetType}:${assetID}`, channel)
 }
 
 function assetNumberTriggers(post) {


### PR DESCRIPTION
instead of by `Key` with OID's numeric porsion
filtering by `Key` makes the query historical, which is undesirable for the purposes of this code